### PR TITLE
Add Zenodo release archiving (concept zenodo.21127421)

### DIFF
--- a/.github/workflows/zenodo-archive.yml
+++ b/.github/workflows/zenodo-archive.yml
@@ -1,0 +1,13 @@
+name: Archive release to Zenodo
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  archive:
+    uses: virtualcell/zenodo-maint/.github/workflows/archive.reusable.yml@v1
+    with:
+      tag: ${{ github.event.release.tag_name }}
+    secrets:
+      ZENODO_TOKEN: ${{ secrets.ZENODO_TOKEN }}

--- a/.github/workflows/zenodo-drift.yml
+++ b/.github/workflows/zenodo-drift.yml
@@ -1,0 +1,10 @@
+name: Zenodo drift check
+
+on:
+  schedule:
+    - cron: '0 12 * * 1'
+  workflow_dispatch: {}
+
+jobs:
+  drift:
+    uses: virtualcell/zenodo-maint/.github/workflows/drift.reusable.yml@v1

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,27 @@
+{
+  "upload_type": "software",
+  "title": "compose-api",
+  "license": "mit",
+  "creators": [
+    {
+      "name": "Valencia, Ezequiel",
+      "affiliation": "University of Connecticut School of Medicine"
+    },
+    {
+      "name": "Schaff, James C.",
+      "affiliation": "University of Connecticut School of Medicine",
+      "orcid": "0000-0003-3286-7736"
+    },
+    {
+      "name": "Drescher, Logan",
+      "affiliation": "University of Connecticut School of Medicine"
+    },
+    {
+      "name": "Moraru, Ion I.",
+      "affiliation": "University of Connecticut School of Medicine",
+      "orcid": "0000-0002-3746-9676"
+    }
+  ],
+  "description": "<p>compose-api is an API server for reproducible biological workflows and co-simulations, part of the BioSimulations platform.</p>",
+  "related_identifiers": []
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,22 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it using these metadata."
+title: "compose-api"
+type: software
+repository-code: "https://github.com/biosimulations/compose-api"
+license: MIT
+doi: 10.5281/zenodo.21127421   # concept DOI (all versions)
+authors:
+  - family-names: "Valencia"
+    given-names: "Ezequiel"
+    affiliation: "University of Connecticut School of Medicine"
+  - family-names: "Schaff"
+    given-names: "James C."
+    affiliation: "University of Connecticut School of Medicine"
+    orcid: "https://orcid.org/0000-0003-3286-7736"
+  - family-names: "Drescher"
+    given-names: "Logan"
+    affiliation: "University of Connecticut School of Medicine"
+  - family-names: "Moraru"
+    given-names: "Ion I."
+    affiliation: "University of Connecticut School of Medicine"
+    orcid: "https://orcid.org/0000-0002-3746-9676"

--- a/LICENSE
+++ b/LICENSE
@@ -1,15 +1,21 @@
-Apache Software License 2.0
+MIT License
 
-Copyright (c) 2025, Jim Schaff
+Copyright (c) 2025 BioSimulations
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-http://www.apache.org/licenses/LICENSE-2.0
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Wires release archiving to Zenodo concept **10.5281/zenodo.21127421** via the `virtualcell/zenodo-maint` reusable workflow, with a corrected author list (Ion Moraru as final author). Also relicenses the repo to MIT (LICENSE).

- **CITATION.cff** — citation + concept DOI
- **.zenodo.json** — deposit metadata
- **zenodo-archive.yml** — on `release: published`
- **zenodo-drift.yml** — weekly drift check

`ZENODO_TOKEN` secret already configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)